### PR TITLE
feat: add "restart server" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,13 @@
         "aliases": ["ZkC", "zkc"],
         "extensions": [".zkc"]
       }
+    ],
+    "commands": [
+      {
+        "command": "zkc.restartServer",
+        "title": "Restart Server",
+        "category": "ZkC"
+      }
     ]
   },
   "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,16 +32,13 @@ export function activate(context: vscode.ExtensionContext) {
 
   client = new LanguageClient("zkc", "ZkC", serverOptions, clientOptions);
   client.onDidChangeState((event) => {
-    //if (event.newState === State.Running) {
-    client.info("ZkC language server started.");
-    //  }
+    client.info("Language server started.");
   });
   client.start();
 
   context.subscriptions.push(
     vscode.commands.registerCommand("zkc.restartServer", async () => {
-      await client.stop();
-      client.start();
+      await client.restart();
     })
   );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,11 +31,15 @@ export function activate(context: vscode.ExtensionContext) {
   };
 
   client = new LanguageClient("zkc", "ZkC", serverOptions, clientOptions);
+  // log client starting.
   client.onDidChangeState((event) => {
-    client.info("Language server started.");
+    if (event.newState === State.Running) {
+      client.info("Language server started.");
+    }
   });
+  // start client
   client.start();
-
+  // register restart command
   context.subscriptions.push(
     vscode.commands.registerCommand("zkc.restartServer", async () => {
       await client.restart();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ import {
 
 let client: LanguageClient;
 
-export function activate(_context: vscode.ExtensionContext) {
+export function activate(context: vscode.ExtensionContext) {
   const serverOptions: ServerOptions = {
     command: "zkc",
     args: ["lsp"],
@@ -37,6 +37,13 @@ export function activate(_context: vscode.ExtensionContext) {
     //  }
   });
   client.start();
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("zkc.restartServer", async () => {
+      await client.stop();
+      client.start();
+    })
+  );
 }
 
 export function deactivate(): Thenable<void> | undefined {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a VS Code command and small lifecycle wiring around the language client; no auth/data-path changes.
> 
> **Overview**
> Adds a new contributed command, `zkc.restartServer`, so users can restart the ZkC language server from VS Code.
> 
> Updates `activate` to accept the extension `context`, log only when the LSP client reaches `State.Running`, and registers the restart command to call `client.restart()` via `context.subscriptions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ffd69d3b037fbbe216512cbb90389655b5d278a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->