### PR TITLE
feat: enable logging from lsp server

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zkc-vscode",
   "displayName": "ZkC",
   "description": "ZkC language support",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Consensys/zkc-vscode-extension.git"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ let client: LanguageClient;
 export function activate(context: vscode.ExtensionContext) {
   const serverOptions: ServerOptions = {
     command: "zkc",
-    args: ["lsp"],
+    args: ["lsp", "-v"],
   };
 
   const clientOptions: LanguageClientOptions = {


### PR DESCRIPTION
This simply modifies the extension to start the `zkc lsp` server with the `-v` flag.  This means that logging information will be passed through into the VS Code "Output" window.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to the LSP server launch arguments plus a version bump; low likelihood of affecting functionality beyond increased logging.
> 
> **Overview**
> The extension now launches the `zkc` LSP server with the `-v` flag, enabling verbose server logging to flow through the VS Code language client/output.
> 
> Also bumps the extension version from `0.1.0` to `0.2.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78a912e3e2017991dd577b9375a9a25086ec3905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->